### PR TITLE
fix3:  Liquid syntax error (line 50):  ERROR at brace-expansion/README.md

### DIFF
--- a/backend/node_modules/brace-expansion/README.md
+++ b/backend/node_modules/brace-expansion/README.md
@@ -38,7 +38,7 @@ expand('file-{a..e..2}.jpg')
 expand('file{00..10..5}.jpg')
 // => ['file00.jpg', 'file05.jpg', 'file10.jpg']
 
-expand('{{A..C},{a..c}}')
+expand('{{A..C}},{a..c}}')
 // => ['A', 'B', 'C', 'a', 'b', 'c']
 
 expand('ppp{,config,oe{,conf}}')


### PR DESCRIPTION
Liquid SyntaxError : at brace-expansion/README.md
for Variable : expand('{{A..C},{a..c}}') at Line 41

Which I changed to expand('{{A..C}},{a..c}}')